### PR TITLE
18-fix-aws-modules

### DIFF
--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -148,6 +148,13 @@ resource "aws_instance" "node" {
     device_index = 1
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"  # This enforces IMDSv2
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "disabled"
+  }
+
   tags = {
     Name = var.name
   }

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/outputs.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/outputs.tf
@@ -21,7 +21,3 @@ output "node-data-private-ip" {
 output "node-security-group-id" {
     value = aws_security_group.node_mgmt_sg.id
 }
-
-output "tg_node" {
-    value =  data.tg_node.node
-}

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -15,7 +15,6 @@ This module deploys a single Trustgrid module on an EC2 instance in AWS and auto
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.7.0 |
-| <a name="requirement_tg"></a> [tg](#requirement\_tg) | >= 1.4.0 |
 
 ## Providers
 
@@ -23,7 +22,6 @@ This module deploys a single Trustgrid module on an EC2 instance in AWS and auto
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_tg"></a> [tg](#provider\_tg) | >= 1.4.0 |
 
 ## Modules
 
@@ -47,13 +45,12 @@ No modules.
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.mgmt_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [cloudinit_config.cloud_init](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
-| [tg_node.node](https://registry.terraform.io/providers/trustgrid/tg/latest/docs/data-sources/node) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface | `list` | n/a | yes |
+| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface. Recommended to include any desired default security groups. | `list` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
 | <a name="input_enroll_endpoint"></a> [enroll\_endpoint](#input\_enroll\_endpoint) | Determines which Trustgrid Tenant the node is registered to | `string` | `"https://keymaster.trustgrid.io/v2/enroll"` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use | `string` | n/a | yes |
@@ -63,13 +60,11 @@ No modules.
 | <a name="input_is_wggateway"></a> [is\_wggateway](#input\_is\_wggateway) | Determines if security group should allow port 51820 inbound for Wireguard | `bool` | `false` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | AWS Key Pair for ubuntu user in EC2 instance | `string` | n/a | yes |
 | <a name="input_license"></a> [license](#input\_license) | The Trustgrid license given from the API or Portal | `string` | n/a | yes |
-| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface | `list` | n/a | yes |
+| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface. Recommended to include any desired default security groups. | `list` | n/a | yes |
 | <a name="input_management_subnet_id"></a> [management\_subnet\_id](#input\_management\_subnet\_id) | Subnet ID for management traffic (needs to be able to reach the internet) | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Instance name | `string` | n/a | yes |
 | <a name="input_root_block_device_encrypt"></a> [root\_block\_device\_encrypt](#input\_root\_block\_device\_encrypt) | Should the root device be encrypted in AWS | `bool` | `true` | no |
 | <a name="input_root_block_device_size"></a> [root\_block\_device\_size](#input\_root\_block\_device\_size) | Size of the root volume in GB | `number` | `30` | no |
-| <a name="input_tg_fqdn"></a> [tg\_fqdn](#input\_tg\_fqdn) | FQDN of the Trustgrid Node associated with the license | `string` | n/a | yes |
-| <a name="input_tg_node_timeout"></a> [tg\_node\_timeout](#input\_tg\_node\_timeout) | Number of seconds to wait to confirm the node is online via the Trustgrid API before failing | `number` | `600` | no |
 
 ## Outputs
 
@@ -81,5 +76,4 @@ No modules.
 | <a name="output_node-mgmt-private-ip"></a> [node-mgmt-private-ip](#output\_node-mgmt-private-ip) | n/a |
 | <a name="output_node-mgmt-public-ip"></a> [node-mgmt-public-ip](#output\_node-mgmt-public-ip) | n/a |
 | <a name="output_node-security-group-id"></a> [node-security-group-id](#output\_node-security-group-id) | n/a |
-| <a name="output_tg_node"></a> [tg\_node](#output\_tg\_node) | n/a |
 <!-- END_TF_DOCS -->

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -16,7 +16,7 @@ variable "management_subnet_id" {
 
 variable "management_security_group_ids" {
   type        = list
-  description = "Security group IDs for the management interface"
+  description = "Security group IDs for the management interface. Recommended to include any desired default security groups."
 }
 
 variable "data_subnet_id" {
@@ -26,7 +26,7 @@ variable "data_subnet_id" {
 
 variable "data_security_group_ids" {
   type        = list
-  description = "Security group IDs for the data interface"
+  description = "Security group IDs for the data interface. Recommended to include any desired default security groups."
 }
 
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -86,16 +86,3 @@ variable enroll_endpoint {
   description = "Determines which Trustgrid Tenant the node is registered to"
   default = "https://keymaster.trustgrid.io/v2/enroll"
 }
-
-variable "tg_fqdn" {
-  type = string
-  description = "FQDN of the Trustgrid Node associated with the license"
-  
-}
-
-variable "tg_node_timeout" {
-  type = number
-  default = 600
-  description = "Number of seconds to wait to confirm the node is online via the Trustgrid API before failing"
-  
-}


### PR DESCRIPTION
removed the tg_node data source as this caused any failure to take 10 minutes to time out even on actions like destroy.  We can provide an example outside the module in the future. Also removed tg from the required_providers. 

Updated to fix the two warning being shown regarding the region and the user_data.