### PR TITLE
pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.merge_commit_sha }}
         fetch-depth: '0'
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.71.0 
+      uses: anothrNick/github-tag-action@f278d49d30cdd8775cc3e7dd00b5ee11686ee297 # 1.71.0
       env:
         WITH_V: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to 40-char commit SHAs
- Tags are mutable and can be force-pushed (as happened with aquasecurity/trivy-action in March 2026); SHAs are immutable
- Version comments (e.g. `# v4`) preserve readability

## Test plan
- [ ] CI passes