### PR TITLE
fix(aws/single-node-auto-reg): split EIP association to avoid race condition

### DIFF
--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 data "aws_ami" "trustgrid-node-ami" {
-  owners      = [ "079972220921" ]
-  most_recent      = true
+  owners      = ["079972220921"]
+  most_recent = true
   filter {
-    name = "name"
+    name   = "name"
     values = ["trustgrid-node-2204*"]
   }
 }
@@ -30,19 +30,19 @@ data "cloudinit_config" "cloud_init" {
   part {
     content_type = "text/cloud-config"
     filename     = "bootstrap.cfg"
-    content      = templatefile("${path.module}/templates/cloud-init.yaml.tpl", 
-    { 
-      license = var.license
-      })
+    content = templatefile("${path.module}/templates/cloud-init.yaml.tpl",
+      {
+        license = var.license
+    })
   }
 
   part {
     content_type = "text/x-shellscript"
     filename     = "bootstrap.sh"
-    content      = templatefile("${path.module}/scripts/bootstrap.sh.tpl", 
-    { 
-      region = data.aws_region.current.region,
-      enroll_endpoint = var.enroll_endpoint
+    content = templatefile("${path.module}/scripts/bootstrap.sh.tpl",
+      {
+        region          = data.aws_region.current.region,
+        enroll_endpoint = var.enroll_endpoint
     })
   }
 }
@@ -58,52 +58,52 @@ resource "aws_security_group" "node_mgmt_sg" {
 }
 
 resource "aws_security_group_rule" "tcp_tggw" {
-  count = var.is_tggateway ? 1 : 0
+  count             = var.is_tggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.tggateway_port
   to_port           = var.tggateway_port
   protocol          = "tcp"
-  cidr_blocks       = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid TCP Tunnel"
 }
 
 resource "aws_security_group_rule" "udp_tggw" {
-  count = var.is_tggateway ? 1 : 0
+  count             = var.is_tggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.tggateway_port
   to_port           = var.tggateway_port
   protocol          = "udp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid UDP Tunnel"
 }
 
 resource "aws_security_group_rule" "udp_wggw" {
-  count = var.is_wggateway ? 1 : 0
+  count             = var.is_wggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.wggateway_port
   to_port           = var.wggateway_port
   protocol          = "udp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Wireguard UDP Tunnel"
 }
 
 resource "aws_security_group_rule" "tcp_appgw" {
-  count = var.is_appgateway ? 1 : 0
+  count             = var.is_appgateway ? 1 : 0
   type              = "ingress"
   from_port         = var.appgateway_port
   to_port           = var.appgateway_port
   protocol          = "tcp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid App Gateway"
 }
 
 resource "aws_network_interface" "management_eni" {
   subnet_id         = var.management_subnet_id
-  security_groups   = concat ( var.management_security_group_ids, [ aws_security_group.node_mgmt_sg.id ] )
+  security_groups   = concat(var.management_security_group_ids, [aws_security_group.node_mgmt_sg.id])
   source_dest_check = false
 
   tags = {
@@ -112,9 +112,9 @@ resource "aws_network_interface" "management_eni" {
 }
 
 resource "aws_network_interface" "data_eni" {
-  subnet_id         = var.data_subnet_id
-  security_groups   = var.data_security_group_ids
-#  private_ips       = [var.data_ip]
+  subnet_id       = var.data_subnet_id
+  security_groups = var.data_security_group_ids
+  #  private_ips       = [var.data_ip]
   source_dest_check = false
 
   tags = {
@@ -124,7 +124,6 @@ resource "aws_network_interface" "data_eni" {
 
 resource "aws_eip" "mgmt_ip" {
   domain = "vpc"
-  network_interface = aws_network_interface.management_eni.id
 
   tags = {
     Name = "${var.name}-mgmt-ip"
@@ -132,27 +131,27 @@ resource "aws_eip" "mgmt_ip" {
 }
 
 resource "aws_instance" "node" {
-  ami                     = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami.id
-  instance_type           = var.instance_type
-  key_name                = var.key_pair_name
+  ami           = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami.id
+  instance_type = var.instance_type
+  key_name      = var.key_pair_name
 
-  user_data_base64        = data.cloudinit_config.cloud_init.rendered
+  user_data_base64 = data.cloudinit_config.cloud_init.rendered
 
-  iam_instance_profile    = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
+  iam_instance_profile = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
 
   network_interface {
     network_interface_id = aws_network_interface.management_eni.id
-    device_index = 0
+    device_index         = 0
   }
 
   network_interface {
     network_interface_id = aws_network_interface.data_eni.id
-    device_index = 1
+    device_index         = 1
   }
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "required"  # This enforces IMDSv2
+    http_tokens                 = "required" # This enforces IMDSv2
     http_put_response_hop_limit = 1
     instance_metadata_tags      = "disabled"
   }
@@ -162,7 +161,7 @@ resource "aws_instance" "node" {
   }
 
   root_block_device {
-    encrypted = var.root_block_device_encrypt
+    encrypted   = var.root_block_device_encrypt
     volume_size = var.root_block_device_size
     volume_type = "gp3"
   }
@@ -170,5 +169,12 @@ resource "aws_instance" "node" {
   lifecycle {
     ignore_changes = all
   }
+}
+
+resource "aws_eip_association" "mgmt_ip_association" {
+  allocation_id        = aws_eip.mgmt_ip.id
+  network_interface_id = aws_network_interface.management_eni.id
+
+  depends_on = [aws_instance.node]
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/outputs.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/outputs.tf
@@ -1,23 +1,23 @@
 output "node-instance-id" {
-    value = aws_instance.node.id
+  value = aws_instance.node.id
 }
 
 output "node-instance-ami-id" {
-    value = aws_instance.node.ami
+  value = aws_instance.node.ami
 }
 
 output "node-mgmt-public-ip" {
-    value = aws_eip.mgmt_ip.public_ip
+  value = aws_eip.mgmt_ip.public_ip
 }
 
 output "node-mgmt-private-ip" {
-    value = one(aws_network_interface.management_eni.private_ips)
+  value = one(aws_network_interface.management_eni.private_ips)
 }
 
 output "node-data-private-ip" {
-    value = one(aws_network_interface.data_eni.private_ips)
+  value = one(aws_network_interface.data_eni.private_ips)
 }
 
 output "node-security-group-id" {
-    value = aws_security_group.node_mgmt_sg.id
+  value = aws_security_group.node_mgmt_sg.id
 }

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -55,7 +55,7 @@ No modules.
 | <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface. Recommended to include any desired default security groups. | `list(string)` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
 | <a name="input_enroll_endpoint"></a> [enroll\_endpoint](#input\_enroll\_endpoint) | Determines which Trustgrid Tenant the node is registered to | `string` | `"https://keymaster.trustgrid.io/v2/enroll"` | no |
-| <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for cluster route management. | `string` | `null` | no |
+| <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for managing AWS resources such as route table entries for clustered nodes. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Node instance type | `string` | `"t3.small"` | no |
 | <a name="input_is_appgateway"></a> [is\_appgateway](#input\_is\_appgateway) | Determines if security group should allow port 443 inbound for Application Gateway | `bool` | `false` | no |
 | <a name="input_is_tggateway"></a> [is\_tggateway](#input\_is\_tggateway) | Determines if security group should allow tcp/udp port 8443 inbound for Trustgrid Tunnels | `bool` | `false` | no |

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -32,6 +32,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eip.mgmt_ip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip_association.mgmt_ip_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_instance.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_network_interface.data_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_network_interface.management_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
@@ -51,7 +52,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_appgateway_port"></a> [appgateway\_port](#input\_appgateway\_port) | Port for Application Gateway (TCP) | `number` | `443` | no |
-| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface. Recommended to include any desired default security groups. | `list` | n/a | yes |
+| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface. Recommended to include any desired default security groups. | `list(string)` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
 | <a name="input_enroll_endpoint"></a> [enroll\_endpoint](#input\_enroll\_endpoint) | Determines which Trustgrid Tenant the node is registered to | `string` | `"https://keymaster.trustgrid.io/v2/enroll"` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for cluster route management. | `string` | `null` | no |
@@ -61,7 +62,7 @@ No modules.
 | <a name="input_is_wggateway"></a> [is\_wggateway](#input\_is\_wggateway) | Determines if security group should allow port 51820 inbound for Wireguard | `bool` | `false` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | AWS Key Pair for ubuntu user in EC2 instance | `string` | n/a | yes |
 | <a name="input_license"></a> [license](#input\_license) | The Trustgrid license given from the API or Portal | `string` | n/a | yes |
-| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface. Recommended to include any desired default security groups. | `list` | n/a | yes |
+| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface. Recommended to include any desired default security groups. | `list(string)` | n/a | yes |
 | <a name="input_management_subnet_id"></a> [management\_subnet\_id](#input\_management\_subnet\_id) | Subnet ID for management traffic (needs to be able to reach the internet) | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Instance name | `string` | n/a | yes |
 | <a name="input_root_block_device_encrypt"></a> [root\_block\_device\_encrypt](#input\_root\_block\_device\_encrypt) | Should the root device be encrypted in AWS | `bool` | `true` | no |

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -16,7 +16,7 @@ variable "management_subnet_id" {
 }
 
 variable "management_security_group_ids" {
-  type        = list(any)
+  type        = list(string)
   description = "Security group IDs for the management interface. Recommended to include any desired default security groups."
 }
 
@@ -26,7 +26,7 @@ variable "data_subnet_id" {
 }
 
 variable "data_security_group_ids" {
-  type        = list(any)
+  type        = list(string)
   description = "Security group IDs for the data interface. Recommended to include any desired default security groups."
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -16,7 +16,7 @@ variable "management_subnet_id" {
 }
 
 variable "management_security_group_ids" {
-  type        = list
+  type        = list(any)
   description = "Security group IDs for the management interface. Recommended to include any desired default security groups."
 }
 
@@ -26,7 +26,7 @@ variable "data_subnet_id" {
 }
 
 variable "data_security_group_ids" {
-  type        = list
+  type        = list(any)
   description = "Security group IDs for the data interface. Recommended to include any desired default security groups."
 }
 
@@ -49,27 +49,27 @@ variable "instance_type" {
   }
 }
 
-variable key_pair_name {
+variable "key_pair_name" {
   type        = string
   description = "AWS Key Pair for ubuntu user in EC2 instance"
 }
 
-variable root_block_device_encrypt {
-  type = bool
+variable "root_block_device_encrypt" {
+  type        = bool
   description = "Should the root device be encrypted in AWS"
-  default = true
+  default     = true
 }
 
-variable root_block_device_size {
-  type = number
+variable "root_block_device_size" {
+  type        = number
   description = "Size of the root volume in GB"
-  default = 30 
+  default     = 30
 }
 
-variable is_tggateway {
-  type = bool
+variable "is_tggateway" {
+  type        = bool
   description = "Determines if security group should allow tcp/udp port 8443 inbound for Trustgrid Tunnels"
-  default = false
+  default     = false
 }
 
 variable "tggateway_port" {
@@ -91,21 +91,21 @@ variable "wggateway_port" {
 }
 
 variable "is_wggateway" {
-  type = bool
+  type        = bool
   description = "Determines if security group should allow port 51820 inbound for Wireguard"
-  default = false
+  default     = false
 }
 
-variable is_appgateway {
-  type = bool
+variable "is_appgateway" {
+  type        = bool
   description = "Determines if security group should allow port 443 inbound for Application Gateway"
-  default = false
+  default     = false
 }
 
-variable enroll_endpoint {
-  type = string
+variable "enroll_endpoint" {
+  type        = string
   description = "Determines which Trustgrid Tenant the node is registered to"
-  default = "https://keymaster.trustgrid.io/v2/enroll"
+  default     = "https://keymaster.trustgrid.io/v2/enroll"
 }
 
 variable "trustgrid_ami_id" {

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 data "aws_ami" "trustgrid-node-ami" {
-  owners      = [ "079972220921" ]
-  most_recent      = true
+  owners      = ["079972220921"]
+  most_recent = true
   filter {
-    name = "name"
+    name   = "name"
     values = ["trustgrid-node-2204*"]
   }
 }
@@ -34,52 +34,52 @@ resource "aws_security_group" "node_mgmt_sg" {
 }
 
 resource "aws_security_group_rule" "tcp_tggw" {
-  count = var.is_tggateway ? 1 : 0
+  count             = var.is_tggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.tggateway_port
   to_port           = var.tggateway_port
   protocol          = "tcp"
-  cidr_blocks       = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid TCP Tunnel"
 }
 
 resource "aws_security_group_rule" "udp_tggw" {
-  count = var.is_tggateway ? 1 : 0
+  count             = var.is_tggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.tggateway_port
   to_port           = var.tggateway_port
   protocol          = "udp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid UDP Tunnel"
 }
 
 resource "aws_security_group_rule" "udp_wggw" {
-  count = var.is_wggateway ? 1 : 0
+  count             = var.is_wggateway ? 1 : 0
   type              = "ingress"
   from_port         = var.wggateway_port
   to_port           = var.wggateway_port
   protocol          = "udp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Wireguard UDP Tunnel"
 }
 
 resource "aws_security_group_rule" "tcp_appgw" {
-  count = var.is_appgateway ? 1 : 0
+  count             = var.is_appgateway ? 1 : 0
   type              = "ingress"
   from_port         = var.appgateway_port
   to_port           = var.appgateway_port
   protocol          = "tcp"
-  cidr_blocks        = [ "0.0.0.0/0" ]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node_mgmt_sg.id
   description       = "Trustgrid App Gateway"
 }
 
 resource "aws_network_interface" "management_eni" {
   subnet_id         = var.management_subnet_id
-  security_groups   = concat ( var.management_security_group_ids, [ aws_security_group.node_mgmt_sg.id ] )
+  security_groups   = concat(var.management_security_group_ids, [aws_security_group.node_mgmt_sg.id])
   source_dest_check = false
 
   tags = {
@@ -88,9 +88,9 @@ resource "aws_network_interface" "management_eni" {
 }
 
 resource "aws_network_interface" "data_eni" {
-  subnet_id         = var.data_subnet_id
-  security_groups   = var.data_security_group_ids
-#  private_ips       = [var.data_ip]
+  subnet_id       = var.data_subnet_id
+  security_groups = var.data_security_group_ids
+  #  private_ips       = [var.data_ip]
   source_dest_check = false
 
   tags = {
@@ -100,7 +100,6 @@ resource "aws_network_interface" "data_eni" {
 
 resource "aws_eip" "mgmt_ip" {
   domain = "vpc"
-  network_interface = aws_network_interface.management_eni.id
 
   tags = {
     Name = "${var.name}-mgmt-ip"
@@ -110,18 +109,18 @@ resource "aws_eip" "mgmt_ip" {
 resource "aws_instance" "node" {
   ami           = data.aws_ami.trustgrid-node-ami.id
   instance_type = var.instance_type
-  key_name = var.key_pair_name
+  key_name      = var.key_pair_name
 
-  iam_instance_profile    = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
+  iam_instance_profile = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
 
   network_interface {
     network_interface_id = aws_network_interface.management_eni.id
-    device_index = 0
+    device_index         = 0
   }
 
   network_interface {
     network_interface_id = aws_network_interface.data_eni.id
-    device_index = 1
+    device_index         = 1
   }
 
   tags = {
@@ -129,7 +128,7 @@ resource "aws_instance" "node" {
   }
 
   root_block_device {
-    encrypted = var.root_block_device_encrypt
+    encrypted   = var.root_block_device_encrypt
     volume_size = var.root_block_device_size
     volume_type = "gp3"
   }
@@ -137,5 +136,12 @@ resource "aws_instance" "node" {
   lifecycle {
     ignore_changes = all
   }
+}
+
+resource "aws_eip_association" "mgmt_ip_association" {
+  allocation_id        = aws_eip.mgmt_ip.id
+  network_interface_id = aws_network_interface.management_eni.id
+
+  depends_on = [aws_instance.node]
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/outputs.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/outputs.tf
@@ -1,23 +1,23 @@
 output "node-instance-id" {
-    value = aws_instance.node.id
+  value = aws_instance.node.id
 }
 
 output "node-instance-ami-id" {
-    value = aws_instance.node.ami
+  value = aws_instance.node.ami
 }
 
 output "node-mgmt-public-ip" {
-    value = aws_eip.mgmt_ip.public_ip
+  value = aws_eip.mgmt_ip.public_ip
 }
 
 output "node-mgmt-private-ip" {
-    value = one(aws_network_interface.management_eni.private_ips)
+  value = one(aws_network_interface.management_eni.private_ips)
 }
 
 output "node-data-private-ip" {
-    value = one(aws_network_interface.data_eni.private_ips)
+  value = one(aws_network_interface.data_eni.private_ips)
 }
 
 output "node-security-group-id" {
-    value = aws_security_group.node_mgmt_sg.id
+  value = aws_security_group.node_mgmt_sg.id
 }

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
@@ -32,6 +32,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eip.mgmt_ip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip_association.mgmt_ip_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_instance.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_network_interface.data_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_network_interface.management_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
@@ -50,7 +51,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_appgateway_port"></a> [appgateway\_port](#input\_appgateway\_port) | Port for Application Gateway (TCP) | `number` | `443` | no |
-| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface | `list` | n/a | yes |
+| <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface | `list(string)` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for managing AWS resources such as route table entries for clustered nodes. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Node instance type | `string` | `"t3.small"` | no |
@@ -58,7 +59,7 @@ No modules.
 | <a name="input_is_tggateway"></a> [is\_tggateway](#input\_is\_tggateway) | Determines if security group should allow tcp/udp port 8443 inbound for Trustgrid Tunnels | `bool` | `false` | no |
 | <a name="input_is_wggateway"></a> [is\_wggateway](#input\_is\_wggateway) | Determines if security group should allow port 51820 inbound for Wireguard | `bool` | `false` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | AWS Key Pair for ubuntu user in EC2 instance | `string` | n/a | yes |
-| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface | `list` | n/a | yes |
+| <a name="input_management_security_group_ids"></a> [management\_security\_group\_ids](#input\_management\_security\_group\_ids) | Security group IDs for the management interface | `list(string)` | n/a | yes |
 | <a name="input_management_subnet_id"></a> [management\_subnet\_id](#input\_management\_subnet\_id) | Subnet ID for management traffic (needs to be able to reach the internet) | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Instance name | `string` | n/a | yes |
 | <a name="input_root_block_device_encrypt"></a> [root\_block\_device\_encrypt](#input\_root\_block\_device\_encrypt) | Should the root device be encrypted in AWS | `bool` | `true` | no |

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
@@ -11,7 +11,7 @@ variable "management_subnet_id" {
 }
 
 variable "management_security_group_ids" {
-  type        = list
+  type        = list(string)
   description = "Security group IDs for the management interface"
 }
 
@@ -21,7 +21,7 @@ variable "data_subnet_id" {
 }
 
 variable "data_security_group_ids" {
-  type        = list
+  type        = list(string)
   description = "Security group IDs for the data interface"
 }
 
@@ -44,27 +44,27 @@ variable "instance_type" {
   }
 }
 
-variable key_pair_name {
+variable "key_pair_name" {
   type        = string
   description = "AWS Key Pair for ubuntu user in EC2 instance"
 }
 
-variable root_block_device_encrypt {
-  type = bool
+variable "root_block_device_encrypt" {
+  type        = bool
   description = "Should the root device be encrypted in AWS"
-  default = true
+  default     = true
 }
 
-variable root_block_device_size {
-  type = number
+variable "root_block_device_size" {
+  type        = number
   description = "Size of the root volume in GB"
-  default = 30 
+  default     = 30
 }
 
-variable is_tggateway {
-  type = bool
+variable "is_tggateway" {
+  type        = bool
   description = "Determines if security group should allow tcp/udp port 8443 inbound for Trustgrid Tunnels"
-  default = false
+  default     = false
 }
 
 variable "tggateway_port" {
@@ -86,14 +86,14 @@ variable "wggateway_port" {
 }
 
 variable "is_wggateway" {
-  type = bool
+  type        = bool
   description = "Determines if security group should allow port 51820 inbound for Wireguard"
-  default = false
+  default     = false
 }
 
-variable is_appgateway {
-  type = bool
+variable "is_appgateway" {
+  type        = bool
   description = "Determines if security group should allow port 443 inbound for Application Gateway"
-  default = false
+  default     = false
 }
 


### PR DESCRIPTION
## Description

Fixes #35

The `aws_eip` resource was associating directly with the management ENI via its `network_interface` argument, which caused a race condition — Terraform would attempt `AssociateAddress` while the EC2 instance was still in `pending` state, resulting in:

```
api error IncorrectInstanceState: The pending-instance-creation instance to which
'eni-...' is attached is not in a valid state for this operation
```

## Changes

- Removed the inline `network_interface` association from `aws_eip.mgmt_ip`
- Added a dedicated `aws_eip_association.mgmt_ip_association` resource with an explicit `depends_on = [aws_instance.node]`, ensuring the association only happens after the instance is fully running
- Applied `terraform fmt` alignment fixes

## Validation

```
terraform init -backend=false && terraform validate
# Success! The configuration is valid.
```