### PR TITLE
fix(aws): reverse EIP association dependency so EIP is bound before instance boots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,7 @@ Makefile, and no Go/Python test suite** in this repo. All quality checks are Ter
 
 ## Build / Lint / Test Commands
 
-**There are no configured test framework commands in this repo.** No `make test`, no
-`pytest`, no `go test`. All validation is Terraform CLI only.
+All validation and testing is Terraform CLI only — no `make test`, `pytest`, or `go test`.
 
 ### Standard per-directory workflow
 
@@ -36,6 +35,7 @@ Run inside each module or example directory you modify — no top-level script e
 terraform init                # required before anything else
 terraform fmt -recursive      # rewrites files in place; always commit the result
 terraform validate            # static type/reference check; requires init
+terraform test                # runs .tftest.hcl tests using mock providers (no credentials needed)
 terraform plan                # verify against provider backend; needs real credentials
 ```
 
@@ -67,10 +67,51 @@ tfsec .    # or: checkov -d .
 terraform-docs markdown table --output-file README.md --output-mode inject .
 ```
 
+### Terraform tests
+
+AWS modules use the native Terraform test framework (`.tftest.hcl`). Tests live in a
+`tests/` subdirectory inside each module directory and use mock providers so they run
+without real AWS credentials.
+
+**When to add tests:** any time you add or modify an AWS Terraform module.
+
+**What to test:**
+- Key security defaults (EIP domain, `source_dest_check`, IMDSv2, root volume encryption)
+- Conditional resource counts (`length(aws_security_group_rule.foo) == 1` when a flag is set)
+- Port/protocol correctness for gateway rules
+- Variable `validation` block rejections via `expect_failures`
+
+**Pattern:**
+
+```hcl
+# tests/module.tftest.hcl
+
+mock_provider "aws" {
+  mock_data "aws_ami"    { defaults = { id = "ami-0123456789abcdef0" } }
+  mock_data "aws_subnet" { defaults = { vpc_id = "vpc-0123456789abcdef0" } }
+  # add other data sources the module uses
+}
+
+variables {
+  # supply all required variables with safe test values
+}
+
+run "descriptive_test_name" {
+  command = plan
+
+  assert {
+    condition     = aws_eip.mgmt_ip.domain == "vpc"
+    error_message = "EIP must be allocated in VPC domain"
+  }
+}
+```
+
+Run tests with: `terraform init -backend=false && terraform test`
+
 ### CI pipeline
 
 `.github/workflows/release.yml` bumps a semver tag on merge to `main`. It does **not**
-run Terraform validate or plan. There is no automated Terraform CI at this time.
+run Terraform validate, plan, or test. There is no automated Terraform CI at this time.
 
 ### Cross-variable validation constraints require `terraform plan`
 
@@ -187,6 +228,7 @@ Every shell script and `*.sh.tpl` template must open with `#!/bin/bash` followed
 | Start every bootstrap script with `set -euo pipefail` | Write scripts that silently swallow errors |
 | Regenerate `<!-- BEGIN_TF_DOCS -->` via `terraform-docs` | Hand-edit the generated table |
 | Scope `terraform plan` to the directory being modified | Run plan against unrelated modules |
+| Add `tests/module.tftest.hcl` when adding/modifying AWS modules | Skip tests because there's no CI |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,12 @@ run "descriptive_test_name" {
 
 Run tests with: `terraform init -backend=false && terraform test`
 
+> **Lock file side effect:** `terraform init` creates a `.terraform.lock.hcl` with pinned
+> provider versions. If you run `terraform-docs` after `terraform init`, the Providers table
+> in the README will show locked versions (e.g. `6.41.0`) instead of the module's declared
+> constraint (`>= 2.7.0`). This is misleading for reusable modules. Always revert README
+> changes caused by this before committing: `git checkout <module>/readme.md`
+
 ### CI pipeline
 
 `.github/workflows/release.yml` bumps a semver tag on merge to `main`. It does **not**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ tflint --init && tflint
 tfsec .    # or: checkov -d .
 
 # terraform-docs — https://terraform-docs.io/
-terraform-docs markdown table --output-file README.md --output-mode inject .
+# --lockfile=false prevents pinned versions from a local .terraform.lock.hcl overwriting
+# the module's declared version constraints in the README Providers table
+terraform-docs markdown table --lockfile=false --output-file README.md --output-mode inject .
 ```
 
 ### Terraform tests
@@ -107,12 +109,6 @@ run "descriptive_test_name" {
 ```
 
 Run tests with: `terraform init -backend=false && terraform test`
-
-> **Lock file side effect:** `terraform init` creates a `.terraform.lock.hcl` with pinned
-> provider versions. If you run `terraform-docs` after `terraform init`, the Providers table
-> in the README will show locked versions (e.g. `6.41.0`) instead of the module's declared
-> constraint (`>= 2.7.0`). This is misleading for reusable modules. Always revert README
-> changes caused by this before committing: `git checkout <module>/readme.md`
 
 ### CI pipeline
 
@@ -200,7 +196,7 @@ Every module README must include the TF_DOCS marker pair — never hand-edit bet
 
 For examples, keep narrative content above the markers and regenerate reference
 tables with:
-`terraform-docs markdown table --output-file README.md .`
+`terraform-docs markdown table --lockfile=false --output-file README.md --output-mode inject .`
 
 ### Shell scripts and `.tpl` bootstrap files
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -130,6 +130,11 @@ resource "aws_eip" "mgmt_ip" {
   }
 }
 
+resource "aws_eip_association" "mgmt_ip_association" {
+  allocation_id        = aws_eip.mgmt_ip.id
+  network_interface_id = aws_network_interface.management_eni.id
+}
+
 resource "aws_instance" "node" {
   ami           = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami.id
   instance_type = var.instance_type
@@ -169,12 +174,7 @@ resource "aws_instance" "node" {
   lifecycle {
     ignore_changes = all
   }
-}
 
-resource "aws_eip_association" "mgmt_ip_association" {
-  allocation_id        = aws_eip.mgmt_ip.id
-  network_interface_id = aws_network_interface.management_eni.id
-
-  depends_on = [aws_instance.node]
+  depends_on = [aws_eip_association.mgmt_ip_association]
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
@@ -1,0 +1,134 @@
+mock_provider "aws" {
+  mock_data "aws_ami" {
+    defaults = {
+      id = "ami-0123456789abcdef0"
+    }
+  }
+  mock_data "aws_iam_instance_profile" {
+    defaults = {
+      name = "test-profile"
+      arn  = "arn:aws:iam::123456789012:instance-profile/test-profile"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+  mock_data "aws_subnet" {
+    defaults = {
+      vpc_id = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+mock_provider "cloudinit" {}
+
+variables {
+  name                          = "test-node"
+  management_subnet_id          = "subnet-mgmt0123456789"
+  management_security_group_ids = ["sg-0123456789abcdef0"]
+  data_subnet_id                = "subnet-data0123456789"
+  data_security_group_ids       = ["sg-abcdef0123456789"]
+  key_pair_name                 = "test-keypair"
+  license                       = "test-license-key"
+}
+
+run "network_security_defaults" {
+  command = plan
+
+  assert {
+    condition     = aws_eip.mgmt_ip.domain == "vpc"
+    error_message = "EIP must be allocated in VPC domain"
+  }
+
+  assert {
+    condition     = aws_network_interface.management_eni.source_dest_check == false
+    error_message = "Management ENI must have source_dest_check disabled for Trustgrid routing"
+  }
+
+  assert {
+    condition     = aws_network_interface.data_eni.source_dest_check == false
+    error_message = "Data ENI must have source_dest_check disabled for Trustgrid routing"
+  }
+}
+
+run "imdsv2_enforced" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.metadata_options[0].http_tokens == "required"
+    error_message = "IMDSv2 must be enforced (http_tokens = required)"
+  }
+
+  assert {
+    condition     = aws_instance.node.metadata_options[0].http_endpoint == "enabled"
+    error_message = "Instance metadata endpoint must be enabled"
+  }
+}
+
+run "root_volume_encrypted_by_default" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.root_block_device[0].encrypted == true
+    error_message = "Root block device must be encrypted by default"
+  }
+
+  assert {
+    condition     = aws_instance.node.root_block_device[0].volume_type == "gp3"
+    error_message = "Root block device must use gp3 volume type"
+  }
+}
+
+run "no_gateway_rules_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_security_group_rule.tcp_tggw) == 0
+    error_message = "TCP gateway rule must not be created when is_tggateway is false"
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.udp_tggw) == 0
+    error_message = "UDP gateway rule must not be created when is_tggateway is false"
+  }
+}
+
+run "tggateway_opens_correct_ports" {
+  command = plan
+
+  variables {
+    is_tggateway = true
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.tcp_tggw) == 1
+    error_message = "TCP gateway rule must be created when is_tggateway is true"
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.udp_tggw) == 1
+    error_message = "UDP gateway rule must be created when is_tggateway is true"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.tcp_tggw[0].from_port == 8443
+    error_message = "TCP gateway rule must use default port 8443"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.udp_tggw[0].from_port == 8443
+    error_message = "UDP gateway rule must use default port 8443"
+  }
+}
+
+run "instance_type_validation_rejects_invalid" {
+  command = plan
+
+  expect_failures = [var.instance_type]
+
+  variables {
+    instance_type = "m5.large"
+  }
+}

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -21,8 +21,6 @@ data "aws_iam_instance_profile" "instance_profile" {
   name  = var.instance_profile_name
 }
 
-data "aws_region" "current" {}
-
 data "aws_subnet" "mgmt_subnet" {
   id = var.management_subnet_id
 }

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -106,6 +106,11 @@ resource "aws_eip" "mgmt_ip" {
   }
 }
 
+resource "aws_eip_association" "mgmt_ip_association" {
+  allocation_id        = aws_eip.mgmt_ip.id
+  network_interface_id = aws_network_interface.management_eni.id
+}
+
 resource "aws_instance" "node" {
   ami           = data.aws_ami.trustgrid-node-ami.id
   instance_type = var.instance_type
@@ -136,12 +141,7 @@ resource "aws_instance" "node" {
   lifecycle {
     ignore_changes = all
   }
-}
 
-resource "aws_eip_association" "mgmt_ip_association" {
-  allocation_id        = aws_eip.mgmt_ip.id
-  network_interface_id = aws_network_interface.management_eni.id
-
-  depends_on = [aws_instance.node]
+  depends_on = [aws_eip_association.mgmt_ip_association]
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
@@ -1,0 +1,112 @@
+mock_provider "aws" {
+  mock_data "aws_ami" {
+    defaults = {
+      id = "ami-0123456789abcdef0"
+    }
+  }
+  mock_data "aws_iam_instance_profile" {
+    defaults = {
+      name = "test-profile"
+      arn  = "arn:aws:iam::123456789012:instance-profile/test-profile"
+    }
+  }
+  mock_data "aws_subnet" {
+    defaults = {
+      vpc_id = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+variables {
+  name                          = "test-node"
+  management_subnet_id          = "subnet-mgmt0123456789"
+  management_security_group_ids = ["sg-0123456789abcdef0"]
+  data_subnet_id                = "subnet-data0123456789"
+  data_security_group_ids       = ["sg-abcdef0123456789"]
+  key_pair_name                 = "test-keypair"
+}
+
+run "network_security_defaults" {
+  command = plan
+
+  assert {
+    condition     = aws_eip.mgmt_ip.domain == "vpc"
+    error_message = "EIP must be allocated in VPC domain"
+  }
+
+  assert {
+    condition     = aws_network_interface.management_eni.source_dest_check == false
+    error_message = "Management ENI must have source_dest_check disabled for Trustgrid routing"
+  }
+
+  assert {
+    condition     = aws_network_interface.data_eni.source_dest_check == false
+    error_message = "Data ENI must have source_dest_check disabled for Trustgrid routing"
+  }
+}
+
+run "root_volume_encrypted_by_default" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.root_block_device[0].encrypted == true
+    error_message = "Root block device must be encrypted by default"
+  }
+
+  assert {
+    condition     = aws_instance.node.root_block_device[0].volume_type == "gp3"
+    error_message = "Root block device must use gp3 volume type"
+  }
+}
+
+run "no_gateway_rules_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_security_group_rule.tcp_tggw) == 0
+    error_message = "TCP gateway rule must not be created when is_tggateway is false"
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.udp_tggw) == 0
+    error_message = "UDP gateway rule must not be created when is_tggateway is false"
+  }
+}
+
+run "tggateway_opens_correct_ports" {
+  command = plan
+
+  variables {
+    is_tggateway = true
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.tcp_tggw) == 1
+    error_message = "TCP gateway rule must be created when is_tggateway is true"
+  }
+
+  assert {
+    condition     = length(aws_security_group_rule.udp_tggw) == 1
+    error_message = "UDP gateway rule must be created when is_tggateway is true"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.tcp_tggw[0].from_port == 8443
+    error_message = "TCP gateway rule must use default port 8443"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.udp_tggw[0].from_port == 8443
+    error_message = "UDP gateway rule must use default port 8443"
+  }
+}
+
+run "instance_type_validation_rejects_invalid" {
+  command = plan
+
+  expect_failures = [var.instance_type]
+
+  variables {
+    instance_type = "m5.large"
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the dependency order for `aws_eip_association` in both `trustgrid_single_node_auto_reg` and `trustgrid_single_node_manual_reg` — EIP is now associated with the management ENI **before** the instance is created, guaranteeing the EIP is bound when the node first boots and runs cloud-init
- Adds `terraform test` coverage for both modules using mock providers (no AWS credentials required)

Fixes #37 — follow-up to #36.

**Previous order (broken):** `management_eni → instance → eip_association`
PR #36 fixed the `IncorrectInstanceState` API race but left a window where cloud-init could run before the EIP was associated.

**New order:** `management_eni → eip_association → instance`
Associating the EIP with the ENI while it's in `available` state (before instance creation) avoids both problems: no API conflict, and the EIP is guaranteed bound at first boot.

## Test plan

- [ ] `terraform test` passes for `trustgrid_single_node_auto_reg` (6 tests)
- [ ] `terraform test` passes for `trustgrid_single_node_manual_reg` (5 tests)
- [ ] Verify no `.terraform/` or `.terraform.lock.hcl` files are included in the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)