### PR TITLE
fix(aws): replace ignore_changes=all with targeted lifecycle + destruction protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,8 +241,9 @@ These patterns are consistent across the entire codebase — always follow them:
 1. `terraform { required_providers {} }` block in every `main.tf`.
 2. `snake_case` for all Terraform identifiers without exception.
 3. `set -euo pipefail` in every shell and bootstrap script.
-4. `lifecycle { ignore_changes = all }` on VM/instance resources — prevents Terraform
-   from replacing running nodes due to post-boot drift.
+4. `lifecycle { prevent_destroy = true; ignore_changes = [ami, key_name, ...] }` on VM/instance
+   resources — ignores replacement-forcing attribute drift while blocking accidental destroys.
+   In-place attributes (`instance_type`, `tags`, `iam_instance_profile`) are intentionally tracked.
 5. `<!-- BEGIN_TF_DOCS --> / <!-- END_TF_DOCS -->` markers in all module READMEs.
 6. `sensitive = true` on SSH keys and license variables.
 7. `identity { type = "SystemAssigned" }` on Azure VMs — required for cluster HA

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -175,6 +175,8 @@ resource "aws_instance" "node" {
     volume_type = "gp3"
   }
 
+  disable_api_termination = true
+
   lifecycle {
     prevent_destroy = true
     ignore_changes = [

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -172,7 +172,12 @@ resource "aws_instance" "node" {
   }
 
   lifecycle {
-    ignore_changes = all
+    prevent_destroy = true
+    ignore_changes = [
+      ami,
+      key_name,
+      user_data_base64,
+    ]
   }
 
   depends_on = [aws_eip_association.mgmt_ip_association]

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.7.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -128,6 +128,10 @@ resource "aws_eip" "mgmt_ip" {
   tags = {
     Name = "${var.name}-mgmt-ip"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_eip_association" "mgmt_ip_association" {

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -148,14 +148,8 @@ resource "aws_instance" "node" {
 
   iam_instance_profile = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.management_eni.id
-    device_index         = 0
-  }
-
-  network_interface {
-    network_interface_id = aws_network_interface.data_eni.id
-    device_index         = 1
   }
 
   metadata_options {
@@ -187,5 +181,11 @@ resource "aws_instance" "node" {
   }
 
   depends_on = [aws_eip_association.mgmt_ip_association]
+}
+
+resource "aws_network_interface_attachment" "data_eni_attachment" {
+  instance_id          = aws_instance.node.id
+  network_interface_id = aws_network_interface.data_eni.id
+  device_index         = 1
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -30,6 +30,21 @@ aws ec2 modify-instance-attribute \
 
 Then remove the module block from your configuration and run `terraform apply`. If you intend to preserve the infrastructure outside of Terraform management, use `terraform state rm` on each resource instead of destroying them.
 
+### Upgrading from a previous module version (migrating to `aws_network_interface_attachment`)
+
+This module version replaced the deprecated `network_interface` blocks on `aws_instance` with `primary_network_interface` (management ENI) and a separate `aws_network_interface_attachment` resource (data ENI). For existing deployed nodes, Terraform will not know about the attachment resource and will attempt to create it — which fails because the ENI is already attached. Import the existing attachment to resolve this:
+
+```bash
+# Get the attachment ID from the AWS console or CLI:
+aws ec2 describe-network-interfaces \
+  --network-interface-ids <data-eni-id> \
+  --query 'NetworkInterfaces[0].Attachment.AttachmentId' \
+  --output text
+
+# Import it into state:
+terraform import module.<your_module_name>.aws_network_interface_attachment.data_eni_attachment <attachment-id>
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -57,6 +72,7 @@ No modules.
 | [aws_instance.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_network_interface.data_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_network_interface.management_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_network_interface_attachment.data_eni_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_security_group.node_mgmt_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.tcp_appgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.tcp_tggw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -6,21 +6,42 @@ This module deploys a single Trustgrid module on an EC2 instance in AWS and auto
 - Security group attached to the outside interface. Optionally, it will include open ports for Trustgrid gateway services.
 - EC2 instance attached to both interfaces built off the Trustgrid AMI image running the latest Trustgrid software
 - On boot, the Trustgrid license is used to register the node with the Trustgrid control plane
-- The module will then use the Trustgrid terraform provider to verify that the node has successfully registered with the Trustgrid control plane. 
+- The module will then use the Trustgrid terraform provider to verify that the node has successfully registered with the Trustgrid control plane.
 
+## Destruction Protection
+
+This module applies two layers of protection against accidental destruction of the EC2 instance and EIP, since either loss would require the node to be re-registered with the Trustgrid control plane and all associated tunnel configuration rebuilt.
+
+| Resource | Protection | Scope |
+|---|---|---|
+| `aws_instance.node` | `disable_api_termination = true` (AWS API-level) + `prevent_destroy = true` (Terraform-level) | AWS rejects termination API calls regardless of who makes them; Terraform blocks plans that would replace the instance |
+| `aws_eip.mgmt_ip` | `prevent_destroy = true` (Terraform-level) | Terraform blocks plans that would replace the EIP; EIP cannot be released while associated |
+| `aws_network_interface.management_eni` | Implicit (primary ENI) | AWS does not allow the primary network interface to be detached from a running instance |
+
+### To intentionally decommission a node
+
+Before `terraform destroy` (or removing the module block) will succeed, an operator must first disable EC2 termination protection:
+
+```bash
+aws ec2 modify-instance-attribute \
+  --instance-id <instance-id> \
+  --no-disable-api-termination
+```
+
+Then remove the module block from your configuration and run `terraform apply`. If you intend to preserve the infrastructure outside of Terraform management, use `terraform state rm` on each resource instead of destroying them.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.7.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
 
 ## Modules

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
@@ -132,3 +132,17 @@ run "instance_type_validation_rejects_invalid" {
     instance_type = "m5.large"
   }
 }
+
+run "in_place_attributes_are_tracked" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.instance_type == var.instance_type
+    error_message = "instance_type must be tracked so in-place resize is possible via Terraform"
+  }
+
+  assert {
+    condition     = aws_instance.node.tags["Name"] == var.name
+    error_message = "Name tag must be tracked so tag corrections can be applied in-place"
+  }
+}

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -137,7 +137,11 @@ resource "aws_instance" "node" {
   }
 
   lifecycle {
-    ignore_changes = all
+    prevent_destroy = true
+    ignore_changes = [
+      ami,
+      key_name,
+    ]
   }
 
   depends_on = [aws_eip_association.mgmt_ip_association]

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -120,14 +120,8 @@ resource "aws_instance" "node" {
 
   iam_instance_profile = var.instance_profile_name != null ? data.aws_iam_instance_profile.instance_profile[0].name : null
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.management_eni.id
-    device_index         = 0
-  }
-
-  network_interface {
-    network_interface_id = aws_network_interface.data_eni.id
-    device_index         = 1
   }
 
   tags = {
@@ -151,5 +145,11 @@ resource "aws_instance" "node" {
   }
 
   depends_on = [aws_eip_association.mgmt_ip_association]
+}
+
+resource "aws_network_interface_attachment" "data_eni_attachment" {
+  instance_id          = aws_instance.node.id
+  network_interface_id = aws_network_interface.data_eni.id
+  device_index         = 1
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -102,6 +102,10 @@ resource "aws_eip" "mgmt_ip" {
   tags = {
     Name = "${var.name}-mgmt-ip"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_eip_association" "mgmt_ip_association" {

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -140,6 +140,8 @@ resource "aws_instance" "node" {
     volume_type = "gp3"
   }
 
+  disable_api_termination = true
+
   lifecycle {
     prevent_destroy = true
     ignore_changes = [

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.7.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
@@ -30,6 +30,21 @@ aws ec2 modify-instance-attribute \
 
 Then remove the module block from your configuration and run `terraform apply`. If you intend to preserve the infrastructure outside of Terraform management, use `terraform state rm` on each resource instead of destroying them.
 
+### Upgrading from a previous module version (migrating to `aws_network_interface_attachment`)
+
+This module version replaced the deprecated `network_interface` blocks on `aws_instance` with `primary_network_interface` (management ENI) and a separate `aws_network_interface_attachment` resource (data ENI). For existing deployed nodes, Terraform will not know about the attachment resource and will attempt to create it — which fails because the ENI is already attached. Import the existing attachment to resolve this:
+
+```bash
+# Get the attachment ID from the AWS console or CLI:
+aws ec2 describe-network-interfaces \
+  --network-interface-ids <data-eni-id> \
+  --query 'NetworkInterfaces[0].Attachment.AttachmentId' \
+  --output text
+
+# Import it into state:
+terraform import module.<your_module_name>.aws_network_interface_attachment.data_eni_attachment <attachment-id>
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -56,6 +71,7 @@ No modules.
 | [aws_instance.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_network_interface.data_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_network_interface.management_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_network_interface_attachment.data_eni_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_security_group.node_mgmt_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.tcp_appgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.tcp_tggw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
@@ -8,20 +8,40 @@ The module handles the creation of the following AWS resources :
 - Security group attached to the outside interface. Optionally, it will include open ports for Trustgrid gateway services.
 - EC2 instance attached to both interfaces built off the Trustgrid AMI image running the latest Trustgrid software
 
+## Destruction Protection
 
+This module applies two layers of protection against accidental destruction of the EC2 instance and EIP, since either loss would require the node to be re-registered with the Trustgrid control plane and all associated tunnel configuration rebuilt.
+
+| Resource | Protection | Scope |
+|---|---|---|
+| `aws_instance.node` | `disable_api_termination = true` (AWS API-level) + `prevent_destroy = true` (Terraform-level) | AWS rejects termination API calls regardless of who makes them; Terraform blocks plans that would replace the instance |
+| `aws_eip.mgmt_ip` | `prevent_destroy = true` (Terraform-level) | Terraform blocks plans that would replace the EIP; EIP cannot be released while associated |
+| `aws_network_interface.management_eni` | Implicit (primary ENI) | AWS does not allow the primary network interface to be detached from a running instance |
+
+### To intentionally decommission a node
+
+Before `terraform destroy` (or removing the module block) will succeed, an operator must first disable EC2 termination protection:
+
+```bash
+aws ec2 modify-instance-attribute \
+  --instance-id <instance-id> \
+  --no-disable-api-termination
+```
+
+Then remove the module block from your configuration and run `terraform apply`. If you intend to preserve the infrastructure outside of Terraform management, use `terraform state rm` on each resource instead of destroying them.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.7.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
@@ -43,7 +63,6 @@ No modules.
 | [aws_security_group_rule.udp_wggw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.trustgrid-node-ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_instance_profile.instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.mgmt_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
@@ -110,3 +110,17 @@ run "instance_type_validation_rejects_invalid" {
     instance_type = "m5.large"
   }
 }
+
+run "in_place_attributes_are_tracked" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.instance_type == var.instance_type
+    error_message = "instance_type must be tracked so in-place resize is possible via Terraform"
+  }
+
+  assert {
+    condition     = aws_instance.node.tags["Name"] == var.name
+    error_message = "Name tag must be tracked so tag corrections can be applied in-place"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #39

Replaces the blunt `ignore_changes = all` lifecycle on both AWS node modules with a targeted approach that:

- Ignores only the attributes that force **replacement** (`ami`, `key_name`, `user_data_base64`) so AMI drift is still silenced
- Leaves in-place-capable attributes (`instance_type`, `tags`, `iam_instance_profile`, etc.) tracked by Terraform, enabling e.g. instance type resizes without out-of-band changes
- Adds two layers of destruction protection on the EC2 instance and EIP, since losing either requires re-registration with the Trustgrid control plane and rebuilding all tunnel config

## What changed

| File | Change |
|---|---|
| Both `main.tf` | `ignore_changes = [ami, key_name, ...]` + `prevent_destroy = true` on instance and EIP; `disable_api_termination = true` on instance |
| Both `main.tf` | Deprecated `network_interface` blocks replaced with `primary_network_interface` (mgmt ENI) + `aws_network_interface_attachment` resource (data ENI) |
| Both `main.tf` | AWS provider version constraint bumped from `>= 2.7.0` to `>= 6.0.0` |
| Both `tests/module.tftest.hcl` | New `in_place_attributes_are_tracked` run block asserting `instance_type` and `tags.Name` flow through |
| Both `readme.md` | Destruction Protection section added with protection table, decommission steps, and migration instructions for the ENI attachment change |
| `AGENTS.md` | Observed convention #4 updated to reflect the new lifecycle pattern |

## Destruction protection layers

| Resource | Protection |
|---|---|
| `aws_instance.node` | `disable_api_termination = true` (AWS API rejects termination regardless of caller) + `prevent_destroy = true` (Terraform blocks replacement plans) |
| `aws_eip.mgmt_ip` | `prevent_destroy = true` (EIP identity is critical for gateway nodes — changing it breaks tunnel endpoints and peer firewall rules) |
| `aws_network_interface.management_eni` | Implicit — AWS does not allow detaching the primary ENI from a running instance |

Note: `prevent_destroy` does **not** fire when the module block is removed entirely — only `disable_api_termination` provides that protection for the instance. See the README decommission steps for the operator procedure.

## Migration note for existing deployments

The move from `network_interface` blocks to `aws_network_interface_attachment` for the data ENI means existing deployed nodes will need to import the attachment into state before applying. The README includes the exact `terraform import` command.

## Test plan

- `terraform test` passes in both modules (6/7 runs each) ✅
- Operator verified: instance type resize applies in-place ✅
- Operator verified: EC2 termination protection blocks `terraform apply` destroy attempt ✅