### PR TITLE
feat(aws): gen3 instance support, cluster role module, and node module improvements

### DIFF
--- a/aws/terraform/modules/iam/trustgrid_cluster_role/README.md
+++ b/aws/terraform/modules/iam/trustgrid_cluster_role/README.md
@@ -1,0 +1,47 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.44.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.trustgrid_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.trustgrid_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.cluster_ip_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.route_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cluster_ip_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.route_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_cluster_ip_failover"></a> [enable\_cluster\_ip\_failover](#input\_enable\_cluster\_ip\_failover) | Grant permissions for secondary private IP assignment/unassignment (cluster IP failover). | `bool` | `false` | no |
+| <a name="input_enable_route_failover"></a> [enable\_route\_failover](#input\_enable\_route\_failover) | Grant permissions for route table manipulation (route-based cluster failover). Requires route\_table\_ids. | `bool` | `false` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the IAM role, policies, and instance profile. | `string` | `"trustgrid-cluster"` | no |
+| <a name="input_route_table_ids"></a> [route\_table\_ids](#input\_route\_table\_ids) | Route table IDs the role may manage. Required when enable\_route\_failover is true. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_profile_name"></a> [profile\_name](#output\_profile\_name) | Name of the IAM instance profile — pass this to the node module's instance\_profile\_name input. |
+| <a name="output_role"></a> [role](#output\_role) | The IAM role resource. |
+<!-- END_TF_DOCS -->

--- a/aws/terraform/modules/iam/trustgrid_cluster_role/main.tf
+++ b/aws/terraform/modules/iam/trustgrid_cluster_role/main.tf
@@ -1,0 +1,101 @@
+terraform {
+  required_version = ">= 1.2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  route_table_arns = [
+    for id in var.route_table_ids :
+    "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:route-table/${id}"
+  ]
+}
+
+data "aws_iam_policy_document" "route_failover" {
+  count = var.enable_route_failover ? 1 : 0
+
+  statement {
+    actions   = ["ec2:DescribeRouteTables"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ec2:CreateRoute",
+      "ec2:DeleteRoute",
+    ]
+    resources = local.route_table_arns
+  }
+}
+
+data "aws_iam_policy_document" "cluster_ip_failover" {
+  count = var.enable_cluster_ip_failover ? 1 : 0
+
+  statement {
+    sid = "DescribeForFailover"
+    actions = [
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeInstances",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageSecondaryIPs"
+    actions = [
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:UnassignPrivateIpAddresses",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "trustgrid_cluster" {
+  name_prefix = "${var.name_prefix}-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Sid       = ""
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_route_failover || var.enable_cluster_ip_failover
+      error_message = "At least one of enable_route_failover or enable_cluster_ip_failover must be true."
+    }
+    precondition {
+      condition     = !var.enable_route_failover || length(var.route_table_ids) > 0
+      error_message = "route_table_ids must be provided when enable_route_failover is true."
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "route_failover" {
+  count       = var.enable_route_failover ? 1 : 0
+  name_prefix = "${var.name_prefix}-route-failover-"
+  role        = aws_iam_role.trustgrid_cluster.name
+  policy      = data.aws_iam_policy_document.route_failover[0].json
+}
+
+resource "aws_iam_role_policy" "cluster_ip_failover" {
+  count       = var.enable_cluster_ip_failover ? 1 : 0
+  name_prefix = "${var.name_prefix}-cluster-ip-failover-"
+  role        = aws_iam_role.trustgrid_cluster.name
+  policy      = data.aws_iam_policy_document.cluster_ip_failover[0].json
+}
+
+resource "aws_iam_instance_profile" "trustgrid_cluster" {
+  name_prefix = "${var.name_prefix}-"
+  role        = aws_iam_role.trustgrid_cluster.name
+}

--- a/aws/terraform/modules/iam/trustgrid_cluster_role/outputs.tf
+++ b/aws/terraform/modules/iam/trustgrid_cluster_role/outputs.tf
@@ -1,0 +1,9 @@
+output "profile_name" {
+  description = "Name of the IAM instance profile — pass this to the node module's instance_profile_name input."
+  value       = aws_iam_instance_profile.trustgrid_cluster.name
+}
+
+output "role" {
+  description = "The IAM role resource."
+  value       = aws_iam_role.trustgrid_cluster
+}

--- a/aws/terraform/modules/iam/trustgrid_cluster_role/tests/module.tftest.hcl
+++ b/aws/terraform/modules/iam/trustgrid_cluster_role/tests/module.tftest.hcl
@@ -1,0 +1,96 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      id = "us-east-1"
+    }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}"
+    }
+  }
+}
+
+run "route_failover_only" {
+  command = plan
+
+  variables {
+    enable_route_failover = true
+    route_table_ids       = ["rtb-0123456789abcdef0"]
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.route_failover) == 1
+    error_message = "Route failover policy must be created when enable_route_failover is true"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.cluster_ip_failover) == 0
+    error_message = "Cluster IP policy must not be created when enable_cluster_ip_failover is false"
+  }
+}
+
+run "cluster_ip_failover_only" {
+  command = plan
+
+  variables {
+    enable_cluster_ip_failover = true
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.cluster_ip_failover) == 1
+    error_message = "Cluster IP policy must be created when enable_cluster_ip_failover is true"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.route_failover) == 0
+    error_message = "Route failover policy must not be created when enable_route_failover is false"
+  }
+}
+
+run "both_failover_methods" {
+  command = plan
+
+  variables {
+    enable_route_failover      = true
+    route_table_ids            = ["rtb-0123456789abcdef0", "rtb-abcdef0123456789"]
+    enable_cluster_ip_failover = true
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.route_failover) == 1
+    error_message = "Route failover policy must be created when enable_route_failover is true"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.cluster_ip_failover) == 1
+    error_message = "Cluster IP policy must be created when enable_cluster_ip_failover is true"
+  }
+}
+
+run "neither_failover_method_rejected" {
+  command = plan
+
+  expect_failures = [aws_iam_role.trustgrid_cluster]
+
+  variables {
+    enable_route_failover      = false
+    enable_cluster_ip_failover = false
+  }
+}
+
+run "route_failover_without_route_tables_rejected" {
+  command = plan
+
+  expect_failures = [aws_iam_role.trustgrid_cluster]
+
+  variables {
+    enable_route_failover = true
+    route_table_ids       = []
+  }
+}

--- a/aws/terraform/modules/iam/trustgrid_cluster_role/variables.tf
+++ b/aws/terraform/modules/iam/trustgrid_cluster_role/variables.tf
@@ -1,0 +1,23 @@
+variable "name_prefix" {
+  type        = string
+  description = "Name prefix for the IAM role, policies, and instance profile."
+  default     = "trustgrid-cluster"
+}
+
+variable "enable_route_failover" {
+  type        = bool
+  description = "Grant permissions for route table manipulation (route-based cluster failover). Requires route_table_ids."
+  default     = false
+}
+
+variable "route_table_ids" {
+  type        = list(string)
+  description = "Route table IDs the role may manage. Required when enable_route_failover is true."
+  default     = []
+}
+
+variable "enable_cluster_ip_failover" {
+  type        = bool
+  description = "Grant permissions for secondary private IP assignment/unassignment (cluster IP failover)."
+  default     = false
+}

--- a/aws/terraform/modules/iam/trustgrid_cluster_route_role/README.md
+++ b/aws/terraform/modules/iam/trustgrid_cluster_route_role/README.md
@@ -20,19 +20,21 @@ No modules.
 | [aws_iam_instance_profile.trustgrid-instance-profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.trustgrid-node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.trustgrid-route-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.private-route-table-modifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the role and related resources | `string` | `"trustgrid-cluster-route"` | no |
-| <a name="input_route_table_arns"></a> [route\_table\_arns](#input\_route\_table\_arns) | List of route table ARNs the role will be allowed to manage | `list(string)` | n/a | yes |
+| <a name="input_route_table_ids"></a> [route\_table\_ids](#input\_route\_table\_ids) | List of route table IDs the role will be allowed to manage | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_trustgrid-instance-profile-name"></a> [trustgrid-instance-profile-name](#output\_trustgrid-instance-profile-name) | n/a |
-| <a name="output_trustgrid-node-iam-role"></a> [trustgrid-node-iam-role](#output\_trustgrid-node-iam-role) | n/a |
+| <a name="output_profile_name"></a> [profile\_name](#output\_profile\_name) | n/a |
+| <a name="output_role"></a> [role](#output\_role) | n/a |
 <!-- END_TF_DOCS -->

--- a/aws/terraform/modules/iam/trustgrid_cluster_route_role/README.md
+++ b/aws/terraform/modules/iam/trustgrid_cluster_route_role/README.md
@@ -1,3 +1,5 @@
+> **Deprecated** — Use the [`trustgrid_cluster_role`](../trustgrid_cluster_role) module instead. It supports both route-based and cluster IP failover in a single IAM role/profile, which is required when a node needs both capabilities. This module will not receive new features.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/aws/terraform/modules/iam/trustgrid_cluster_route_role/main.tf
+++ b/aws/terraform/modules/iam/trustgrid_cluster_route_role/main.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {}
 locals {
   route_table_arns = [
     for id in var.route_table_ids :
-    "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:route-table/${id}"
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:route-table/${id}"
   ]
 }
 

--- a/aws/terraform/modules/iam/trustgrid_cluster_route_role/main.tf
+++ b/aws/terraform/modules/iam/trustgrid_cluster_route_role/main.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {}
 locals {
   route_table_arns = [
     for id in var.route_table_ids :
-    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:route-table/${id}"
+    "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:route-table/${id}"
   ]
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 locals {
-  is_pci_path      = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
-  ami_name_pattern = local.is_pci_path ? "trustgrid-node-pci-path-2204*" : "trustgrid-node-2204*"
+  is_gen3          = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
+  ami_name_pattern = local.is_gen3 ? "trustgrid-node-gen3-2204-*" : "trustgrid-node-2204-*"
 }
 
 data "aws_ami" "trustgrid-node-ami" {
@@ -22,7 +22,7 @@ data "aws_ami" "trustgrid-node-ami" {
   }
   filter {
     name   = "tag:InterfaceNaming"
-    values = [local.is_pci_path ? "pci-path" : "pci-slot"]
+    values = [local.is_gen3 ? "gen3" : "gen2"]
   }
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -179,7 +179,7 @@ resource "aws_instance" "node" {
     volume_type = "gp3"
   }
 
-  disable_api_termination = true
+  disable_api_termination = var.disable_api_termination
 
   lifecycle {
     prevent_destroy = true

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/main.tf
@@ -7,12 +7,22 @@ terraform {
   }
 }
 
+locals {
+  is_pci_path      = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
+  ami_name_pattern = local.is_pci_path ? "trustgrid-node-pci-path-2204*" : "trustgrid-node-2204*"
+}
+
 data "aws_ami" "trustgrid-node-ami" {
+  count       = var.trustgrid_ami_id == null ? 1 : 0
   owners      = ["079972220921"]
   most_recent = true
   filter {
     name   = "name"
-    values = ["trustgrid-node-2204*"]
+    values = [local.ami_name_pattern]
+  }
+  filter {
+    name   = "tag:InterfaceNaming"
+    values = [local.is_pci_path ? "pci-path" : "pci-slot"]
   }
 }
 
@@ -140,7 +150,7 @@ resource "aws_eip_association" "mgmt_ip_association" {
 }
 
 resource "aws_instance" "node" {
-  ami           = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami.id
+  ami           = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami[0].id
   instance_type = var.instance_type
   key_name      = var.key_pair_name
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -56,8 +56,8 @@ terraform import module.<your_module_name>.aws_network_interface_attachment.data
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.41.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.7 |
 
 ## Modules
 

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/readme.md
@@ -91,6 +91,7 @@ No modules.
 | <a name="input_appgateway_port"></a> [appgateway\_port](#input\_appgateway\_port) | Port for Application Gateway (TCP) | `number` | `443` | no |
 | <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface. Recommended to include any desired default security groups. | `list(string)` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
+| <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, the EC2 instance cannot be terminated via the AWS API. Disable only when decommissioning the node. | `bool` | `true` | no |
 | <a name="input_enroll_endpoint"></a> [enroll\_endpoint](#input\_enroll\_endpoint) | Determines which Trustgrid Tenant the node is registered to | `string` | `"https://keymaster.trustgrid.io/v2/enroll"` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for managing AWS resources such as route table entries for clustered nodes. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Node instance type | `string` | `"t3.small"` | no |

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
@@ -147,7 +147,7 @@ run "in_place_attributes_are_tracked" {
   }
 }
 
-run "pci_path_c7_instance_type_accepted" {
+run "gen3_c7_instance_type_accepted" {
   command = plan
 
   variables {
@@ -160,7 +160,7 @@ run "pci_path_c7_instance_type_accepted" {
   }
 }
 
-run "pci_path_c8_variant_accepted" {
+run "gen3_c8_variant_accepted" {
   command = plan
 
   variables {
@@ -173,7 +173,7 @@ run "pci_path_c8_variant_accepted" {
   }
 }
 
-run "pci_path_m8azn_accepted" {
+run "gen3_m8azn_accepted" {
   command = plan
 
   variables {
@@ -186,7 +186,7 @@ run "pci_path_m8azn_accepted" {
   }
 }
 
-run "pci_path_m7i_flex_accepted" {
+run "gen3_m7i_flex_accepted" {
   command = plan
 
   variables {

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/tests/module.tftest.hcl
@@ -146,3 +146,114 @@ run "in_place_attributes_are_tracked" {
     error_message = "Name tag must be tracked so tag corrections can be applied in-place"
   }
 }
+
+run "pci_path_c7_instance_type_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "c7a.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "c7a.large"
+    error_message = "c7a instance type must be accepted"
+  }
+}
+
+run "pci_path_c8_variant_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "c8ine.xlarge"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "c8ine.xlarge"
+    error_message = "c8ine instance type must be accepted"
+  }
+}
+
+run "pci_path_m8azn_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "m8azn.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "m8azn.large"
+    error_message = "m8azn instance type must be accepted"
+  }
+}
+
+run "pci_path_m7i_flex_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "m7i-flex.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "m7i-flex.large"
+    error_message = "m7i-flex instance type must be accepted"
+  }
+}
+
+run "graviton_instance_type_rejected" {
+  command = plan
+
+  expect_failures = [var.instance_type]
+
+  variables {
+    instance_type = "c7g.large"
+  }
+}
+
+run "ami_data_source_runs_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(data.aws_ami.trustgrid-node-ami) == 1
+    error_message = "AMI data source must run when no trustgrid_ami_id is provided"
+  }
+}
+
+run "ami_override_skips_data_source" {
+  command = plan
+
+  variables {
+    trustgrid_ami_id = "ami-custom123456789ab"
+  }
+
+  assert {
+    condition     = length(data.aws_ami.trustgrid-node-ami) == 0
+    error_message = "AMI data source must be skipped when trustgrid_ami_id is provided"
+  }
+
+  assert {
+    condition     = aws_instance.node.ami == "ami-custom123456789ab"
+    error_message = "Instance must use the provided trustgrid_ami_id"
+  }
+}
+
+run "disable_api_termination_defaults_true" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.disable_api_termination == true
+    error_message = "disable_api_termination must default to true"
+  }
+}
+
+run "disable_api_termination_can_be_overridden" {
+  command = plan
+
+  variables {
+    disable_api_termination = false
+  }
+
+  assert {
+    condition     = aws_instance.node.disable_api_termination == false
+    error_message = "disable_api_termination must be overridable to false for decommissioning"
+  }
+}

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -113,3 +113,9 @@ variable "trustgrid_ami_id" {
   description = "Optional: Explicit Trustgrid AMI ID to use for the EC2 node. If not set, the latest matching AMI will be used."
   default     = null
 }
+
+variable "disable_api_termination" {
+  type        = bool
+  description = "If true, the EC2 instance cannot be terminated via the AWS API. Disable only when decommissioning the node."
+  default     = true
+}

--- a/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_auto_reg/variables.tf
@@ -43,9 +43,9 @@ variable "instance_type" {
 
   validation {
     condition = (
-      can(regex("^(t3|t3a|c5|c5n|c5a|c6i|c6in|c6a)\\..+$", var.instance_type))
+      can(regex("^(t3|t3a|c5|c5n|c5a|c6i|c6in|c6a|[cm][78][ai][a-z-]*)\\..+$", var.instance_type))
     )
-    error_message = "Instance type must be a valid t3, t3a, c5, c5n, c5a, c6i, c6in, or c6a family instance type (e.g., t3.small, c6i.4xlarge)."
+    error_message = "Instance type must be a valid t3, t3a, c5, c5n, c5a, c6i, c6in, c6a, or a c7/c8/m7/m8 family instance type (e.g., t3.small, c7a.large, m8azn.large)."
   }
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -144,7 +144,7 @@ resource "aws_instance" "node" {
     volume_type = "gp3"
   }
 
-  disable_api_termination = true
+  disable_api_termination = var.disable_api_termination
 
   lifecycle {
     prevent_destroy = true

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 locals {
-  is_pci_path      = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
-  ami_name_pattern = local.is_pci_path ? "trustgrid-node-pci-path-2204*" : "trustgrid-node-2204*"
+  is_gen3          = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
+  ami_name_pattern = local.is_gen3 ? "trustgrid-node-gen3-2204-*" : "trustgrid-node-2204-*"
 }
 
 data "aws_ami" "trustgrid-node-ami" {
@@ -22,7 +22,7 @@ data "aws_ami" "trustgrid-node-ami" {
   }
   filter {
     name   = "tag:InterfaceNaming"
-    values = [local.is_pci_path ? "pci-path" : "pci-slot"]
+    values = [local.is_gen3 ? "gen3" : "gen2"]
   }
 }
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/main.tf
@@ -7,12 +7,22 @@ terraform {
   }
 }
 
+locals {
+  is_pci_path      = can(regex("^[cm][78][ai][a-z-]*\\..+$", var.instance_type))
+  ami_name_pattern = local.is_pci_path ? "trustgrid-node-pci-path-2204*" : "trustgrid-node-2204*"
+}
+
 data "aws_ami" "trustgrid-node-ami" {
+  count       = var.trustgrid_ami_id == null ? 1 : 0
   owners      = ["079972220921"]
   most_recent = true
   filter {
     name   = "name"
-    values = ["trustgrid-node-2204*"]
+    values = [local.ami_name_pattern]
+  }
+  filter {
+    name   = "tag:InterfaceNaming"
+    values = [local.is_pci_path ? "pci-path" : "pci-slot"]
   }
 }
 
@@ -114,7 +124,7 @@ resource "aws_eip_association" "mgmt_ip_association" {
 }
 
 resource "aws_instance" "node" {
-  ami           = data.aws_ami.trustgrid-node-ami.id
+  ami           = var.trustgrid_ami_id != null ? var.trustgrid_ami_id : data.aws_ami.trustgrid-node-ami[0].id
   instance_type = var.instance_type
   key_name      = var.key_pair_name
 

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
@@ -88,6 +88,7 @@ No modules.
 | <a name="input_appgateway_port"></a> [appgateway\_port](#input\_appgateway\_port) | Port for Application Gateway (TCP) | `number` | `443` | no |
 | <a name="input_data_security_group_ids"></a> [data\_security\_group\_ids](#input\_data\_security\_group\_ids) | Security group IDs for the data interface | `list(string)` | n/a | yes |
 | <a name="input_data_subnet_id"></a> [data\_subnet\_id](#input\_data\_subnet\_id) | Subnet ID for data traffic | `string` | n/a | yes |
+| <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, the EC2 instance cannot be terminated via the AWS API. Disable only when decommissioning the node. | `bool` | `true` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Instance Profile the Trustgrid EC2 node will use for managing AWS resources such as route table entries for clustered nodes. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Node instance type | `string` | `"t3.small"` | no |
 | <a name="input_is_appgateway"></a> [is\_appgateway](#input\_is\_appgateway) | Determines if security group should allow port 443 inbound for Application Gateway | `bool` | `false` | no |

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/readme.md
@@ -56,7 +56,7 @@ terraform import module.<your_module_name>.aws_network_interface_attachment.data
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.41.0 |
 
 ## Modules
 
@@ -100,6 +100,7 @@ No modules.
 | <a name="input_root_block_device_encrypt"></a> [root\_block\_device\_encrypt](#input\_root\_block\_device\_encrypt) | Should the root device be encrypted in AWS | `bool` | `true` | no |
 | <a name="input_root_block_device_size"></a> [root\_block\_device\_size](#input\_root\_block\_device\_size) | Size of the root volume in GB | `number` | `30` | no |
 | <a name="input_tggateway_port"></a> [tggateway\_port](#input\_tggateway\_port) | Port for Trustgrid Gateway (TCP/UDP tunnel) | `number` | `8443` | no |
+| <a name="input_trustgrid_ami_id"></a> [trustgrid\_ami\_id](#input\_trustgrid\_ami\_id) | Optional: Explicit Trustgrid AMI ID to use for the EC2 node. If not set, the latest matching AMI will be used. | `string` | `null` | no |
 | <a name="input_wggateway_port"></a> [wggateway\_port](#input\_wggateway\_port) | Port for Wireguard Gateway (UDP) | `number` | `51820` | no |
 
 ## Outputs

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
@@ -125,7 +125,7 @@ run "in_place_attributes_are_tracked" {
   }
 }
 
-run "pci_path_c7_instance_type_accepted" {
+run "gen3_c7_instance_type_accepted" {
   command = plan
 
   variables {
@@ -138,7 +138,7 @@ run "pci_path_c7_instance_type_accepted" {
   }
 }
 
-run "pci_path_c8_variant_accepted" {
+run "gen3_c8_variant_accepted" {
   command = plan
 
   variables {
@@ -151,7 +151,7 @@ run "pci_path_c8_variant_accepted" {
   }
 }
 
-run "pci_path_m8azn_accepted" {
+run "gen3_m8azn_accepted" {
   command = plan
 
   variables {
@@ -164,7 +164,7 @@ run "pci_path_m8azn_accepted" {
   }
 }
 
-run "pci_path_m7i_flex_accepted" {
+run "gen3_m7i_flex_accepted" {
   command = plan
 
   variables {

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/tests/module.tftest.hcl
@@ -124,3 +124,114 @@ run "in_place_attributes_are_tracked" {
     error_message = "Name tag must be tracked so tag corrections can be applied in-place"
   }
 }
+
+run "pci_path_c7_instance_type_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "c7a.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "c7a.large"
+    error_message = "c7a instance type must be accepted"
+  }
+}
+
+run "pci_path_c8_variant_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "c8ine.xlarge"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "c8ine.xlarge"
+    error_message = "c8ine instance type must be accepted"
+  }
+}
+
+run "pci_path_m8azn_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "m8azn.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "m8azn.large"
+    error_message = "m8azn instance type must be accepted"
+  }
+}
+
+run "pci_path_m7i_flex_accepted" {
+  command = plan
+
+  variables {
+    instance_type = "m7i-flex.large"
+  }
+
+  assert {
+    condition     = aws_instance.node.instance_type == "m7i-flex.large"
+    error_message = "m7i-flex instance type must be accepted"
+  }
+}
+
+run "graviton_instance_type_rejected" {
+  command = plan
+
+  expect_failures = [var.instance_type]
+
+  variables {
+    instance_type = "c7g.large"
+  }
+}
+
+run "ami_data_source_runs_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(data.aws_ami.trustgrid-node-ami) == 1
+    error_message = "AMI data source must run when no trustgrid_ami_id is provided"
+  }
+}
+
+run "ami_override_skips_data_source" {
+  command = plan
+
+  variables {
+    trustgrid_ami_id = "ami-custom123456789ab"
+  }
+
+  assert {
+    condition     = length(data.aws_ami.trustgrid-node-ami) == 0
+    error_message = "AMI data source must be skipped when trustgrid_ami_id is provided"
+  }
+
+  assert {
+    condition     = aws_instance.node.ami == "ami-custom123456789ab"
+    error_message = "Instance must use the provided trustgrid_ami_id"
+  }
+}
+
+run "disable_api_termination_defaults_true" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.node.disable_api_termination == true
+    error_message = "disable_api_termination must default to true"
+  }
+}
+
+run "disable_api_termination_can_be_overridden" {
+  command = plan
+
+  variables {
+    disable_api_termination = false
+  }
+
+  assert {
+    condition     = aws_instance.node.disable_api_termination == false
+    error_message = "disable_api_termination must be overridable to false for decommissioning"
+  }
+}

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
@@ -103,3 +103,9 @@ variable "trustgrid_ami_id" {
   default     = null
 }
 
+variable "disable_api_termination" {
+  type        = bool
+  description = "If true, the EC2 instance cannot be terminated via the AWS API. Disable only when decommissioning the node."
+  default     = true
+}
+

--- a/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
+++ b/aws/terraform/modules/trustgrid_single_node_manual_reg/variables.tf
@@ -38,9 +38,9 @@ variable "instance_type" {
 
   validation {
     condition = (
-      can(regex("^(t3|t3a|c5|c5n|c5a|c6i|c6in|c6a)\\..+$", var.instance_type))
+      can(regex("^(t3|t3a|c5|c5n|c5a|c6i|c6in|c6a|[cm][78][ai][a-z-]*)\\..+$", var.instance_type))
     )
-    error_message = "Instance type must be a valid t3, t3a, c5, c5n, c5a, c6i, c6in, or c6a family instance type (e.g., t3.small, c6i.4xlarge)."
+    error_message = "Instance type must be a valid t3, t3a, c5, c5n, c5a, c6i, c6in, c6a, or a c7/c8/m7/m8 family instance type (e.g., t3.small, c7a.large, m8azn.large)."
   }
 }
 
@@ -95,5 +95,11 @@ variable "is_appgateway" {
   type        = bool
   description = "Determines if security group should allow port 443 inbound for Application Gateway"
   default     = false
+}
+
+variable "trustgrid_ami_id" {
+  type        = string
+  description = "Optional: Explicit Trustgrid AMI ID to use for the EC2 node. If not set, the latest matching AMI will be used."
+  default     = null
 }
 


### PR DESCRIPTION
## Summary

- **Gen3 AMI selection**: Both node modules now automatically select the correct Trustgrid AMI based on instance family. Gen2 (t3/t3a/c5/c6 families) use `trustgrid-node-2204-*` with `InterfaceNaming: gen2`; gen3 (c7/c8/m7/m8 Intel+AMD families) use `trustgrid-node-gen3-2204-*` with `InterfaceNaming: gen3`. Graviton variants are explicitly excluded from validation.
- **AMI override**: Both node modules now support `trustgrid_ami_id` to pin an explicit AMI and skip the data source lookup entirely. Previously missing from `trustgrid_single_node_manual_reg`.
- **`disable_api_termination` variable**: Both node modules expose this as a variable (default `true`) to allow clean decommissioning without state surgery.
- **`trustgrid_cluster_role` module**: New IAM module replacing `trustgrid_cluster_route_role`. Supports route-based failover, cluster IP failover, or both via feature flags (`enable_route_failover`, `enable_cluster_ip_failover`) in a single role/profile. EC2 instances support only one instance profile, so a combined module is required when both capabilities are needed. Old module is soft-deprecated.
- **Bug fix**: `data.aws_region.current.region` (deprecated) updated to `.id` in both IAM modules.

## Test plan

- [ ] Verify gen3 AMI selection works against test tenant with a c7/c8 instance type using `trustgrid_ami_id` override pointing to `trustgrid-node-pci-path-2204-test-2026-05-05-13-59`
- [ ] Verify gen2 AMI lookup still resolves correctly for existing c5/c6 instance types
- [ ] Verify `disable_api_termination = false` allows clean `terraform destroy` without state surgery
- [ ] Deploy `trustgrid_cluster_role` with `enable_cluster_ip_failover = true` and confirm the instance profile grants correct permissions
- [ ] Run `terraform test` in all four affected modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)